### PR TITLE
Button style on pressed #52

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [4.0.1] - August 29, 2022
+
+* Moved pressed state above hovered state.
+* Fix for [Issue #52](https://https://github.com/peiffer-innovations/json_theme/issues/52)
+
 ## [4.0.0+8] - August 9, 2022
 
 * Automated dependency updates

--- a/lib/src/codec/theme_decoder.dart
+++ b/lib/src/codec/theme_decoder.dart
@@ -5308,10 +5308,10 @@ class ThemeDecoder {
             result = decodeColor(value['error']);
           } else if (states.contains(MaterialState.focused)) {
             result = decodeColor(value['focused']);
-          } else if (states.contains(MaterialState.hovered)) {
-            result = decodeColor(value['hovered']);
           } else if (states.contains(MaterialState.pressed)) {
             result = decodeColor(value['pressed']);
+          } else if (states.contains(MaterialState.hovered)) {
+            result = decodeColor(value['hovered']);
           } else if (states.contains(MaterialState.scrolledUnder)) {
             result = decodeColor(value['scrolledUnder']);
           } else if (states.contains(MaterialState.selected)) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '4.0.0+8'
+version: '4.0.1'
 
 environment: 
   sdk: '>=2.17.0 <3.0.0'

--- a/test/json_theme_test.dart
+++ b/test/json_theme_test.dart
@@ -4138,6 +4138,16 @@ void main() {
 
       expect(encoded![stateKey], colorStr);
     }
+
+    /// Test if pressed takes precedence over hovered
+    final materialColor = ThemeDecoder.decodeMaterialStatePropertyColor(
+      colors,
+    );
+    final color = materialColor?.resolve({
+      states['hovered']!,
+      states['pressed']!,
+    });
+    expect(ThemeEncoder.encodeColor(color), colors['pressed']);
   });
 
   test('MaterialStatePropertyDouble', () {


### PR DESCRIPTION
## Description

On desktop platforms 'pressed' color is never taken into account because it always comes as a set with 'hovered' which was above 'pressed'.
I moved 'pressed' above 'hovered'.


## Checklist
- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
