### PR TITLE
Add Material3 InkSparkle support

### DIFF
--- a/lib/src/codec/theme_decoder.dart
+++ b/lib/src/codec/theme_decoder.dart
@@ -4667,6 +4667,8 @@ class ThemeDecoder {
   /// values are:
   ///  * `splash`
   ///  * `ripple`
+  ///  * `sparkle`
+  ///
   static InteractiveInkFeatureFactory? decodeInteractiveInkFeatureFactory(
     dynamic value, {
     bool validate = true,
@@ -4680,6 +4682,7 @@ class ThemeDecoder {
         [
           'splash',
           'ripple',
+          'sparkle',
         ],
         value,
       );
@@ -4698,6 +4701,9 @@ class ThemeDecoder {
           case 'ripple':
             result = InkRipple.splashFactory;
             break;
+
+          case 'sparkle':
+            result = InkSparkle.splashFactory;
         }
       }
     }

--- a/lib/src/codec/theme_encoder.dart
+++ b/lib/src/codec/theme_encoder.dart
@@ -2734,6 +2734,7 @@ class ThemeEncoder {
   /// are:
   ///  * `splash`
   ///  * `ripple`
+  ///  * `sparkle`
   ///
   /// All other values, including `null`, will result in `null`.
   static String? encodeInteractiveInkFeatureFactory(
@@ -2741,10 +2742,12 @@ class ThemeEncoder {
   ) {
     var splashType = InkSplash.splashFactory.runtimeType;
     var rippleType = InkRipple.splashFactory.runtimeType;
+    var sparkleType = InkSparkle.splashFactory.runtimeType;
 
     assert(value == null ||
         value.runtimeType == splashType ||
-        value.runtimeType == rippleType);
+        value.runtimeType == rippleType ||
+        value.runtimeType == sparkleType);
     String? result;
 
     if (value != null) {
@@ -2752,6 +2755,8 @@ class ThemeEncoder {
         result = 'splash';
       } else if (value.runtimeType == rippleType) {
         result = 'ripple';
+      } else if (value.runtimeType == sparkleType) {
+        result = 'sparkle';
       }
     }
 

--- a/lib/src/schema/schemas/enums/interactive_ink_feature_factory_schema.dart
+++ b/lib/src/schema/schemas/enums/interactive_ink_feature_factory_schema.dart
@@ -14,6 +14,7 @@ class InteractiveInkFeatureFactorySchema {
     'oneOf': SchemaHelper.enumSchema([
       'splash',
       'ripple',
+      'sparkle',
     ]),
   };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,29 +1,27 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '4.0.2+1'
+version: '4.0.2+2'
 
-environment: 
+environment:
   sdk: '>=2.17.0 <3.0.0'
 
-analyzer: 
-  exclude: 
+analyzer:
+  exclude:
     - 'lib/generated/**'
 
-
-dependencies: 
-  flutter: 
+dependencies:
+  flutter:
     sdk: 'flutter'
   json_class: '^2.1.2+11'
   json_schema2: '^2.0.2+15'
   meta: '^1.7.0'
 
-dev_dependencies: 
-  flutter_test: 
+dev_dependencies:
+  flutter_test:
     sdk: 'flutter'
 
-
-ignore_updates: 
+ignore_updates:
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/test/json_theme_test.dart
+++ b/test/json_theme_test.dart
@@ -3625,6 +3625,10 @@ void main() {
       ThemeDecoder.decodeInteractiveInkFeatureFactory('ripple'),
       InkRipple.splashFactory,
     );
+    expect(
+      ThemeDecoder.decodeInteractiveInkFeatureFactory('sparkle'),
+      InkSparkle.splashFactory,
+    );
 
     expect(
       ThemeEncoder.encodeInteractiveInkFeatureFactory(InkSplash.splashFactory),
@@ -3633,6 +3637,10 @@ void main() {
     expect(
       ThemeEncoder.encodeInteractiveInkFeatureFactory(InkRipple.splashFactory),
       'ripple',
+    );
+    expect(
+      ThemeEncoder.encodeInteractiveInkFeatureFactory(InkSparkle.splashFactory),
+      'sparkle',
     );
   });
 


### PR DESCRIPTION
## Description

[InkSparkle](https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/ink_sparkle.dart) is a new type of ink for Material 3. If the user sets `useMaterial3` to true in`ThemeData` and attempts to encode the ThemeData, the app crashes due to a failed assertion:
```
'package:json_theme/src/codec/theme_encoder.dart': Failed assertion: line 2745 pos 12: 'value == null ||
I/flutter (13443):         value.runtimeType == splashType ||
I/flutter (13443):         value.runtimeType == rippleType': is not true.
```

This is because the type `sparkleType` is not defined or allowed as a runtime type.

This PR adds InkSparkle support to the package.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
