### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [5.0.2+7] - May 30, 2023
+
+* Automated dependency updates
+
+
 ## [5.0.2+6] - May 2, 2023
 
 * Automated dependency updates
@@ -513,6 +518,7 @@
 * ~~**TODO**: Documentation~~
 * ~~**TODO**: Example App~~
 * ~~**TODO**: Unit Tests~~
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'example'
 description: 'Example application for the JSON Theme'
 publish_to: 'none'
-version: '1.0.0+34'
+version: '1.0.0+35'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -9,8 +9,8 @@ environment:
 dependencies: 
   flutter: 
     sdk: 'flutter'
-  form_validation: '^2.2.1+6'
-  google_fonts: '^4.0.4'
+  form_validation: '^3.0.0'
+  google_fonts: '^4.0.5'
   intl: '^0.18.1'
   json_theme: 
     path: '../'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '5.0.2+6'
+version: '5.0.2+7'
 
 environment: 
   sdk: '>=2.19.0 <4.0.0'
@@ -15,7 +15,7 @@ dependencies:
   flutter: 
     sdk: 'flutter'
   json_class: '^2.2.1+3'
-  json_schema2: '^2.0.4+4'
+  json_schema2: '^2.0.4+8'
   meta: '^1.8.0'
 
 dev_dependencies: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_schema2`: 2.0.4+4 --> 2.0.4+8


Analysis Successful


dependencies:
  * `form_validation`: 2.2.1+6 --> 3.0.0
  * `google_fonts`: 4.0.4 --> 4.0.5


Error!!!
```
Resolving dependencies...


Because every version of json_theme from path depends on json_schema2 ^2.0.4+8 which depends on rest_client ^2.2.1+11, every version of json_theme from path requires rest_client ^2.2.1+11.
And because rest_client >=2.2.1+11 depends on http ^0.13.6 and google_fonts >=4.0.5 depends on http ^1.0.0, json_theme from path is incompatible with google_fonts >=4.0.5.
So, because example depends on both google_fonts ^4.0.5 and json_theme from path, version solving failed.

```

