### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.0.0+1] - June 13, 2023
+
+* Automated dependency updates
+
+
 ## [6.0.0] - June 4th, 2023
 
 * Switched from [json_schema2] to [json_schema] now that it supports Null Safety.
@@ -518,6 +523,7 @@
 * ~~**TODO**: Documentation~~
 * ~~**TODO**: Example App~~
 * ~~**TODO**: Unit Tests~~
+
 
 
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,43 +1,52 @@
 name: 'example'
 description: 'Example application for the JSON Theme'
 publish_to: 'none'
-version: '1.0.0+34'
+version: '1.0.0+35'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
-  flutter:
+dependencies: 
+  flutter: 
     sdk: 'flutter'
-  form_validation: '^3.0.0'
-  google_fonts: '^4.0.4'
+  form_validation: '^3.0.1'
+  google_fonts: '^5.0.0'
   intl: '^0.18.1'
-  json_theme:
+  json_theme: 
     path: '../'
   meta: '^1.9.0'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
 
-flutter:
+
+flutter: 
   uses-material-design: true
-  assets:
+  assets: 
     - 'assets/themes/'
-  fonts:
-    - family: 'lato'
-      fonts:
-        - asset: 'assets/fonts/Lato-Regular.ttf'
+  fonts: 
+    - 
+      family: 'lato'
+      fonts: 
+        - 
+          asset: 'assets/fonts/Lato-Regular.ttf'
 
-    - family: 'metal'
-      fonts:
-        - asset: 'assets/fonts/MetalMania-Regular.ttf'
+    - 
+      family: 'metal'
+      fonts: 
+        - 
+          asset: 'assets/fonts/MetalMania-Regular.ttf'
 
-    - family: 'MaterialIcons'
-      fonts:
-        - asset: 'assets/fonts/MaterialIcons-Regular.ttf'
+    - 
+      family: 'MaterialIcons'
+      fonts: 
+        - 
+          asset: 'assets/fonts/MaterialIcons-Regular.ttf'
 
-ignore_updates:
+
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,28 +1,30 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.0.0'
+version: '6.0.0+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-dependencies:
-  flutter:
+
+dependencies: 
+  flutter: 
     sdk: 'flutter'
   json_class: '^2.2.1+3'
-  json_schema: '^5.0.0'
+  json_schema: '^5.1.1'
   meta: '^1.9.0'
 
-dev_dependencies:
-  flutter_test:
+dev_dependencies: 
+  flutter_test: 
     sdk: 'flutter'
 
-ignore_updates:
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_schema`: 5.0.0 --> 5.1.1


Analysis Successful


dependencies:
  * `form_validation`: 3.0.0 --> 3.0.1
  * `google_fonts`: 4.0.4 --> 5.0.0


Error!!!
```
Resolving dependencies...


Because every version of json_theme from path depends on json_schema ^5.1.1 which depends on http ^0.13.4, every version of json_theme from path requires http ^0.13.4.
And because google_fonts >=4.0.5 depends on http ^1.0.0, json_theme from path is incompatible with google_fonts >=4.0.5.
So, because example depends on both google_fonts ^5.0.0 and json_theme from path, version solving failed.

```

