### PR TITLE
feat: Added JsonMaterialStateProperty class

### DIFF
--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.1.1] - July 23th, 2023
+
+* Added `JsonMaterialStateProperty` class that allows to show values of `MaterialPropertyResolver` in form of type-safe `Map<MaterialState, T>` instead of Instance of '_MaterialStatePropertyWith' on toString() call.
+
 ## [6.1.0] - July 16th, 2023
 
 * Upgraded to json_class 3.0.0

--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [6.1.1] - July 23th, 2023
 
-* Added `JsonMaterialStateProperty` class that allows to show values of `MaterialPropertyResolver` in form of type-safe `Map<MaterialState, T>` instead of Instance of '_MaterialStatePropertyWith' on toString() call.
+* Added `JsonMaterialStateProperty` class that allows to show values of `MaterialPropertyResolver` in form of type-safe `Map<MaterialState?, T>` instead of Instance of '_MaterialStatePropertyWith' on toString() call.
 
 ## [6.1.0] - July 16th, 2023
 

--- a/json_theme/lib/json_theme.dart
+++ b/json_theme/lib/json_theme.dart
@@ -2,3 +2,4 @@ export 'json_theme_schemas.dart';
 //
 export 'src/codec/theme_decoder.dart';
 export 'src/codec/theme_encoder.dart';
+export 'src/model/json_material_state_property.dart';

--- a/json_theme/lib/src/codec/theme_decoder.dart
+++ b/json_theme/lib/src/codec/theme_decoder.dart
@@ -10,7 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:json_class/json_class.dart';
 import 'package:json_theme_annotation/json_theme_annotation.dart';
 
-import '../model/json_material_state_property.dart';
+import '../model/map_material_state_property.dart';
 import '../schema/schema_validator.dart';
 
 /// Decoder capable of converting JSON compatible values into Flutter Theme
@@ -6180,7 +6180,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = JsonMaterialStateProperty.resolveWith((states) {
+        result = MapMaterialStateProperty.resolveWith((states) {
           bool? result;
           if (states.contains(MaterialState.disabled)) {
             result = JsonClass.maybeParseBool(value['disabled']);
@@ -6288,7 +6288,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = JsonMaterialStateProperty.resolveWith((states) {
+          result = MapMaterialStateProperty.resolveWith((states) {
             BorderSide? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeBorderSide(
@@ -6392,7 +6392,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = JsonMaterialStateProperty.resolveWith((states) {
+        result = MapMaterialStateProperty.resolveWith((states) {
           Color? result;
           if (states.contains(MaterialState.disabled)) {
             result = decodeColor(
@@ -6493,7 +6493,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = JsonMaterialStateProperty.resolveWith((states) {
+        result = MapMaterialStateProperty.resolveWith((states) {
           double? result;
           if (states.contains(MaterialState.disabled)) {
             result = JsonClass.maybeParseDouble(value['disabled']);
@@ -6620,7 +6620,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = JsonMaterialStateProperty.resolveWith((states) {
+          result = MapMaterialStateProperty.resolveWith((states) {
             EdgeInsetsGeometry? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeEdgeInsetsGeometry(
@@ -6721,7 +6721,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = JsonMaterialStateProperty.resolveWith((states) {
+        result = MapMaterialStateProperty.resolveWith((states) {
           Icon? result;
           if (states.contains(MaterialState.disabled)) {
             result = decodeIcon(
@@ -6856,7 +6856,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = JsonMaterialStateProperty.resolveWith((states) {
+          result = MapMaterialStateProperty.resolveWith((states) {
             IconThemeData? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeIconThemeData(
@@ -6990,7 +6990,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = JsonMaterialStateProperty.resolveWith((states) {
+          result = MapMaterialStateProperty.resolveWith((states) {
             MouseCursor? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeMouseCursor(
@@ -7126,7 +7126,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = JsonMaterialStateProperty.resolveWith((states) {
+          result = MapMaterialStateProperty.resolveWith((states) {
             OutlinedBorder? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeOutlinedBorder(
@@ -7256,7 +7256,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = JsonMaterialStateProperty.resolveWith((states) {
+          result = MapMaterialStateProperty.resolveWith((states) {
             Size? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeSize(
@@ -7389,7 +7389,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = JsonMaterialStateProperty.resolveWith((states) {
+          result = MapMaterialStateProperty.resolveWith((states) {
             TextStyle? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeTextStyle(

--- a/json_theme/lib/src/codec/theme_decoder.dart
+++ b/json_theme/lib/src/codec/theme_decoder.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:json_class/json_class.dart';
 import 'package:json_theme_annotation/json_theme_annotation.dart';
 
+import '../model/json_material_state_property.dart';
 import '../schema/schema_validator.dart';
 
 /// Decoder capable of converting JSON compatible values into Flutter Theme
@@ -6391,7 +6392,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = MaterialStateProperty.resolveWith((states) {
+        result = JsonMaterialStateProperty.resolveWith((states) {
           Color? result;
           if (states.contains(MaterialState.disabled)) {
             result = decodeColor(

--- a/json_theme/lib/src/codec/theme_decoder.dart
+++ b/json_theme/lib/src/codec/theme_decoder.dart
@@ -6180,7 +6180,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = MaterialStateProperty.resolveWith((states) {
+        result = JsonMaterialStateProperty.resolveWith((states) {
           bool? result;
           if (states.contains(MaterialState.disabled)) {
             result = JsonClass.maybeParseBool(value['disabled']);
@@ -6288,7 +6288,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = MaterialStateProperty.resolveWith((states) {
+          result = JsonMaterialStateProperty.resolveWith((states) {
             BorderSide? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeBorderSide(
@@ -6493,7 +6493,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = MaterialStateProperty.resolveWith((states) {
+        result = JsonMaterialStateProperty.resolveWith((states) {
           double? result;
           if (states.contains(MaterialState.disabled)) {
             result = JsonClass.maybeParseDouble(value['disabled']);
@@ -6620,7 +6620,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = MaterialStateProperty.resolveWith((states) {
+          result = JsonMaterialStateProperty.resolveWith((states) {
             EdgeInsetsGeometry? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeEdgeInsetsGeometry(
@@ -6721,7 +6721,7 @@ class ThemeDecoder {
           validate: validate,
         ));
 
-        result = MaterialStateProperty.resolveWith((states) {
+        result = JsonMaterialStateProperty.resolveWith((states) {
           Icon? result;
           if (states.contains(MaterialState.disabled)) {
             result = decodeIcon(
@@ -6856,7 +6856,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = MaterialStateProperty.resolveWith((states) {
+          result = JsonMaterialStateProperty.resolveWith((states) {
             IconThemeData? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeIconThemeData(
@@ -6990,7 +6990,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = MaterialStateProperty.resolveWith((states) {
+          result = JsonMaterialStateProperty.resolveWith((states) {
             MouseCursor? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeMouseCursor(
@@ -7126,7 +7126,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = MaterialStateProperty.resolveWith((states) {
+          result = JsonMaterialStateProperty.resolveWith((states) {
             OutlinedBorder? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeOutlinedBorder(
@@ -7256,7 +7256,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = MaterialStateProperty.resolveWith((states) {
+          result = JsonMaterialStateProperty.resolveWith((states) {
             Size? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeSize(
@@ -7389,7 +7389,7 @@ class ThemeDecoder {
             validate: validate,
           ));
 
-          result = MaterialStateProperty.resolveWith((states) {
+          result = JsonMaterialStateProperty.resolveWith((states) {
             TextStyle? result;
             if (states.contains(MaterialState.disabled)) {
               result = decodeTextStyle(

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -1,17 +1,24 @@
 // ignore_for_file: curly_braces_in_flow_control_structures
 
 import 'package:flutter/material.dart';
+import 'package:meta/meta.dart' show experimental;
 
-typedef _MapStates<T> = Map<MaterialState, T>;
-
+/// Helper class that allows to expose values of [MaterialPropertyResolver] in
+/// form of type-safe [Map<MaterialState, T>] instead of `Instance of
+/// '_MaterialStatePropertyWith'` via toString() call.
+@immutable
 class JsonMaterialStateProperty<T extends Object>
     implements MaterialStateProperty<T?> {
   const JsonMaterialStateProperty(this.map);
 
-  final _MapStates<T> map;
+  final Map<MaterialState, T> map;
 
   bool get _hasValues => map.values.whereType<T>().isNotEmpty;
 
+  /// Partially copies the behavior of the ThemeDecoder's
+  /// `decodeMaterialStateProperty*` methods but without the `empty` value and
+  /// through [MaterialState.values].
+  @experimental
   @override
   T? resolve(Set<MaterialState> states) {
     if (states.isEmpty || !_hasValues) return null;

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class JsonMaterialStateProperty<T> implements MaterialStateProperty<T> {
+  JsonMaterialStateProperty(this._resolve);
+
+  final MaterialPropertyResolver<T> _resolve;
+
+  @override
+  T resolve(Set<MaterialState> states) => _resolve(states);
+
+  static MaterialStateProperty<T> resolveWith<T>(MaterialPropertyResolver<T> callback) =>
+      JsonMaterialStateProperty<T>(callback);
+
+  @override
+  String toString() {
+    final sb = StringBuffer();
+    MaterialState.values.forEach((state) => sb.write('$state: ${_resolve({state})}\n'));
+    return sb.toString();
+  }
+}

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -4,26 +4,25 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart' show experimental;
 
 /// Helper class that allows to expose values of [MaterialPropertyResolver] in
-/// form of type-safe [Map<MaterialState, T>] instead of `Instance of
+/// form of type-safe [Map<MaterialState?, T>] instead of `Instance of
 /// '_MaterialStatePropertyWith'` via toString() call.
 @immutable
 class JsonMaterialStateProperty<T extends Object>
     implements MaterialStateProperty<T?> {
   const JsonMaterialStateProperty(this.map);
 
-  final Map<MaterialState, T> map;
+  final Map<MaterialState?, T> map;
 
   bool get _hasValues => map.values.whereType<T>().isNotEmpty;
 
   /// Partially copies the behavior of the ThemeDecoder's
-  /// `decodeMaterialStateProperty*` methods but without the `empty` value and
-  /// through [MaterialState.values].
+  /// `decodeMaterialStateProperty*` through [MaterialState.values].
   @experimental
   @override
   T? resolve(Set<MaterialState> states) {
-    if (states.isEmpty || !_hasValues) return null;
+    if (!_hasValues) return null;
     for (final s in MaterialState.values) if (states.contains(s)) return map[s];
-    return null;
+    return map[null];
   }
 
   @override

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -2,55 +2,28 @@
 
 import 'package:flutter/material.dart';
 
-class JsonMaterialStateProperty<T> implements MaterialStateProperty<T> {
-  JsonMaterialStateProperty(this._resolve);
+typedef _MapStates<T> = Map<MaterialState, T>;
 
-  final MaterialPropertyResolver<T> _resolve;
+class JsonMaterialStateProperty<T extends Object>
+    implements MaterialStateProperty<T?> {
+  const JsonMaterialStateProperty(this.map);
+
+  final _MapStates<T> map;
+
+  bool get _hasValues => map.values.whereType<T>().isNotEmpty;
 
   @override
-  T resolve(Set<MaterialState> states) => _resolve(states);
-
-  static MaterialStateProperty<T> resolveWith<T>(MaterialPropertyResolver<T> callback) =>
-      JsonMaterialStateProperty<T>(callback);
-
-  static MaterialStateProperty<T?> fromMap<T>(Map<MaterialState, T?> map) =>
-      JsonMaterialStateProperty<T?>((states) => _fromMap<T?>(states, map));
-
-  static T? _fromMap<T>(Set<MaterialState> states, Map<MaterialState, T?> map) {
-    T? result;
-    if (states.contains(MaterialState.disabled)) {
-      result = map[MaterialState.disabled];
-    } else if (states.contains(MaterialState.dragged)) {
-      result = map[MaterialState.dragged];
-    } else if (states.contains(MaterialState.error)) {
-      result = map[MaterialState.error];
-    } else if (states.contains(MaterialState.focused)) {
-      result = map[MaterialState.focused];
-    } else if (states.contains(MaterialState.pressed)) {
-      result = map[MaterialState.pressed];
-    } else if (states.contains(MaterialState.hovered)) {
-      result = map[MaterialState.hovered];
-    } else if (states.contains(MaterialState.scrolledUnder)) {
-      result = map[MaterialState.scrolledUnder];
-    } else if (states.contains(MaterialState.selected)) {
-      result = map[MaterialState.selected];
-    } else {
-      result = map.values.first;
-    }
-
-    return result;
+  T? resolve(Set<MaterialState> states) {
+    if (states.isEmpty || !_hasValues) return null;
+    for (final s in MaterialState.values) if (states.contains(s)) return map[s];
+    return null;
   }
 
   @override
   String toString() {
-    final map = <MaterialState, T?>{};
-    for (final state in MaterialState.values) map[state] = _resolve({state});
-    map.removeWhere((_, value) => value == null);
-    final sb = StringBuffer('JsonMaterialStateProperty.fromMap<$T>({');
-    if (map.isNotEmpty) {
-      for (final en in map.entries) sb.write('${en.key}: ${en.value}, ');
-    }
-
+    if (!_hasValues) return null.toString();
+    final sb = StringBuffer('JsonMaterialStateProperty({');
+    for (final en in map.entries) sb.write('${en.key}: ${en.value}, ');
     return '${sb.toString().trimRight()}})';
   }
 }

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -46,7 +46,7 @@ class JsonMaterialStateProperty<T> implements MaterialStateProperty<T> {
     final map = <MaterialState, T?>{};
     for (final state in MaterialState.values) map[state] = _resolve({state});
     map.removeWhere((_, value) => value == null);
-    final sb = StringBuffer('${runtimeType}.fromMap<$T>({');
+    final sb = StringBuffer('JsonMaterialStateProperty.fromMap<$T>({');
     if (map.isNotEmpty) {
       for (final en in map.entries) sb.write('${en.key}: ${en.value}, ');
     }

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: curly_braces_in_flow_control_structures
+
 import 'package:flutter/material.dart';
 
 class JsonMaterialStateProperty<T> implements MaterialStateProperty<T> {
@@ -11,10 +13,44 @@ class JsonMaterialStateProperty<T> implements MaterialStateProperty<T> {
   static MaterialStateProperty<T> resolveWith<T>(MaterialPropertyResolver<T> callback) =>
       JsonMaterialStateProperty<T>(callback);
 
+  static MaterialStateProperty<T?> fromMap<T>(Map<MaterialState, T?> map) =>
+      JsonMaterialStateProperty<T?>((states) => _fromMap<T?>(states, map));
+
+  static T? _fromMap<T>(Set<MaterialState> states, Map<MaterialState, T?> map) {
+    T? result;
+    if (states.contains(MaterialState.disabled)) {
+      result = map[MaterialState.disabled];
+    } else if (states.contains(MaterialState.dragged)) {
+      result = map[MaterialState.dragged];
+    } else if (states.contains(MaterialState.error)) {
+      result = map[MaterialState.error];
+    } else if (states.contains(MaterialState.focused)) {
+      result = map[MaterialState.focused];
+    } else if (states.contains(MaterialState.pressed)) {
+      result = map[MaterialState.pressed];
+    } else if (states.contains(MaterialState.hovered)) {
+      result = map[MaterialState.hovered];
+    } else if (states.contains(MaterialState.scrolledUnder)) {
+      result = map[MaterialState.scrolledUnder];
+    } else if (states.contains(MaterialState.selected)) {
+      result = map[MaterialState.selected];
+    } else {
+      result = map.values.first;
+    }
+
+    return result;
+  }
+
   @override
   String toString() {
-    final sb = StringBuffer();
-    MaterialState.values.forEach((state) => sb.write('$state: ${_resolve({state})}\n'));
-    return sb.toString();
+    final map = <MaterialState, T?>{};
+    for (final state in MaterialState.values) map[state] = _resolve({state});
+    map.removeWhere((_, value) => value == null);
+    final sb = StringBuffer('${runtimeType}.fromMap<$T>({');
+    if (map.isNotEmpty) {
+      for (final en in map.entries) sb.write('${en.key}: ${en.value}, ');
+    }
+
+    return '${sb.toString().trimRight()}})';
   }
 }

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -11,6 +11,7 @@ class JsonMaterialStateProperty<T extends Object>
     implements MaterialStateProperty<T?> {
   const JsonMaterialStateProperty(this.map);
 
+  /// Map containing [MaterialState?] and it's corresponding [T] values.
   final Map<MaterialState?, T> map;
 
   bool get _hasValues => map.values.whereType<T>().isNotEmpty;

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -30,7 +30,7 @@ class JsonMaterialStateProperty<T extends Object>
   String toString() {
     if (!_hasValues) return null.toString();
     final sb = StringBuffer('JsonMaterialStateProperty({');
-    for (final en in map.entries) sb.write('${en.key}: ${en.value}, ');
+    for (final entry in map.entries) sb.write('${entry.key}: ${entry.value}, ');
     return '${sb.toString().trimRight()}})';
   }
 }

--- a/json_theme/lib/src/model/json_material_state_property.dart
+++ b/json_theme/lib/src/model/json_material_state_property.dart
@@ -16,8 +16,8 @@ class JsonMaterialStateProperty<T extends Object>
 
   bool get _hasValues => map.values.whereType<T>().isNotEmpty;
 
-  /// Partially copies the behavior of the ThemeDecoder's
-  /// `decodeMaterialStateProperty*` through [MaterialState.values].
+  /// Copies the behavior of the ThemeDecoder's `decodeMaterialStateProperty*`
+  /// through [MaterialState.values].
   @experimental
   @override
   T? resolve(Set<MaterialState> states) {

--- a/json_theme/lib/src/model/map_material_state_property.dart
+++ b/json_theme/lib/src/model/map_material_state_property.dart
@@ -29,16 +29,17 @@ class MapMaterialStateProperty<R extends Object, T extends R?>
 
   @override
   String toString() {
-    final map = <MaterialState, T?>{};
+    final map = <MaterialState?, T?>{};
     // ignore: curly_braces_in_flow_control_structures
     for (final state in MaterialState.values) map[state] = _resolve({state});
+    map[null] = _resolve({}); // Covers "empty" case.
 
     return JsonMaterialStateProperty(_nonNullValueMap(map)).toString();
   }
 
-  Map<MaterialState, R> _nonNullValueMap(Map<MaterialState, T?> map) {
+  Map<MaterialState?, R> _nonNullValueMap(Map<MaterialState?, T?> map) {
     map.removeWhere((_, value) => value == null);
 
-    return Map<MaterialState, R>.unmodifiable(map);
+    return Map<MaterialState?, R>.unmodifiable(map);
   }
 }

--- a/json_theme/lib/src/model/map_material_state_property.dart
+++ b/json_theme/lib/src/model/map_material_state_property.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+import 'json_material_state_property.dart';
+
+class MapMaterialStateProperty<R extends Object, T extends R?>
+    implements MaterialStateProperty<T> {
+  MapMaterialStateProperty(this._resolve);
+
+  final MaterialPropertyResolver<T> _resolve;
+
+  @override
+  T resolve(Set<MaterialState> states) => _resolve(states);
+
+  /// Convenience method for creating a [MaterialStateProperty] from a
+  /// [MaterialPropertyResolver] function alone.
+  ///
+  /// Copied from [MaterialStateProperty].
+  static MaterialStateProperty<T> resolveWith<R extends Object, T extends R?>(
+    MaterialPropertyResolver<T> callback,
+  ) =>
+      MapMaterialStateProperty<R, T>(callback);
+
+  Map<MaterialState, R> _nonNullValueMap(Map<MaterialState, T?> map) {
+    map.removeWhere((_, value) => value == null);
+
+    return Map<MaterialState, R>.unmodifiable(map);
+  }
+
+  @override
+  String toString() {
+    final map = <MaterialState, T?>{};
+    // ignore: curly_braces_in_flow_control_structures
+    for (final state in MaterialState.values) map[state] = _resolve({state});
+
+    return JsonMaterialStateProperty(_nonNullValueMap(map)).toString();
+  }
+}

--- a/json_theme/lib/src/model/map_material_state_property.dart
+++ b/json_theme/lib/src/model/map_material_state_property.dart
@@ -1,15 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:meta/meta.dart' show internal;
 
 import 'json_material_state_property.dart';
 
+/// Helper class that does not break [MaterialStateProperty] resolveWith
+/// contract and on the other hand exposes values as [JsonMaterialStateProperty]
+/// instead of `Instance of '_MaterialStatePropertyWith'` via toString() call.
+@internal
+@immutable
 class MapMaterialStateProperty<R extends Object, T extends R?>
     implements MaterialStateProperty<T> {
+  /// Class is internal, means that it not a part of the public API.
   MapMaterialStateProperty(this._resolve);
 
   final MaterialPropertyResolver<T> _resolve;
-
-  @override
-  T resolve(Set<MaterialState> states) => _resolve(states);
 
   /// Convenience method for creating a [MaterialStateProperty] from a
   /// [MaterialPropertyResolver] function alone.
@@ -20,11 +24,8 @@ class MapMaterialStateProperty<R extends Object, T extends R?>
   ) =>
       MapMaterialStateProperty<R, T>(callback);
 
-  Map<MaterialState, R> _nonNullValueMap(Map<MaterialState, T?> map) {
-    map.removeWhere((_, value) => value == null);
-
-    return Map<MaterialState, R>.unmodifiable(map);
-  }
+  @override
+  T resolve(Set<MaterialState> states) => _resolve(states);
 
   @override
   String toString() {
@@ -33,5 +34,11 @@ class MapMaterialStateProperty<R extends Object, T extends R?>
     for (final state in MaterialState.values) map[state] = _resolve({state});
 
     return JsonMaterialStateProperty(_nonNullValueMap(map)).toString();
+  }
+
+  Map<MaterialState, R> _nonNullValueMap(Map<MaterialState, T?> map) {
+    map.removeWhere((_, value) => value == null);
+
+    return Map<MaterialState, R>.unmodifiable(map);
   }
 }

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.1.0'
+version: '6.1.1'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/json_theme/test/src/model/json_material_state_property_test.dart
+++ b/json_theme/test/src/model/json_material_state_property_test.dart
@@ -11,14 +11,27 @@ void main() => group('JsonMaterialStateProperty', () {
         );
 
         test(
+          'should return null on empty (null) key in map',
+          () => expect(emptyMap.resolve({}), isNull),
+        );
+
+        test(
           'should return null on toString() call',
           () => expect(emptyMap.toString(), null.toString()),
         );
       });
 
       group('with non-empty map input', () {
-        const map = {MaterialState.disabled: true, MaterialState.error: false};
+        const map = {
+          MaterialState.disabled: true,
+          MaterialState.error: false,
+          null: true
+        };
         const property = JsonMaterialStateProperty(map);
+        test(
+          'should return null on empty (null) key in map',
+          () => expect(property.resolve({}), isTrue),
+        );
         test(
           'should throw assertion error on resolve() call',
           () {
@@ -28,7 +41,7 @@ void main() => group('JsonMaterialStateProperty', () {
               reason: 'provides no value for ${MaterialState.values.first}',
             );
             expect(
-              property.resolve({map.keys.first}),
+              property.resolve({map.keys.first!}),
               isTrue,
               reason:
                   'provides ${map.values.first} value for ${map.keys.first}',
@@ -40,7 +53,7 @@ void main() => group('JsonMaterialStateProperty', () {
           'should return full JsonMaterialStateProperty object on toString()',
           () => expect(
             property.toString(),
-            '''JsonMaterialStateProperty({MaterialState.disabled: true, MaterialState.error: false,})''',
+            '''JsonMaterialStateProperty({MaterialState.disabled: true, MaterialState.error: false, null: true,})''',
           ),
         );
       });

--- a/json_theme/test/src/model/json_material_state_property_test.dart
+++ b/json_theme/test/src/model/json_material_state_property_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_theme/src/model/json_material_state_property.dart';
+
+void main() => group('JsonMaterialStateProperty', () {
+      group('with empty map input', () {
+        const emptyMap = JsonMaterialStateProperty<int>({});
+        test(
+          'should return null on resolve() call',
+          () => expect(emptyMap.resolve(MaterialState.values.toSet()), isNull),
+        );
+
+        test(
+          'should return null on toString() call',
+          () => expect(emptyMap.toString(), null.toString()),
+        );
+      });
+
+      group('with non-empty map input', () {
+        const map = {MaterialState.disabled: true, MaterialState.error: false};
+        const property = JsonMaterialStateProperty(map);
+        test(
+          'should throw assertion error on resolve() call',
+          () {
+            expect(
+              property.resolve(MaterialState.values.toSet()),
+              isNull,
+              reason: 'provides no value for ${MaterialState.values.first}',
+            );
+            expect(
+              property.resolve({map.keys.first}),
+              isTrue,
+              reason:
+                  'provides ${map.values.first} value for ${map.keys.first}',
+            );
+          },
+        );
+
+        test(
+          'should return full JsonMaterialStateProperty object on toString()',
+          () => expect(
+            property.toString(),
+            '''JsonMaterialStateProperty({MaterialState.disabled: true, MaterialState.error: false,})''',
+          ),
+        );
+      });
+    });

--- a/json_theme/test/src/model/map_material_state_property_test.dart
+++ b/json_theme/test/src/model/map_material_state_property_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:json_theme/src/model/json_material_state_property.dart';
+import 'package:json_theme/src/model/map_material_state_property.dart';
+
+void main() => group('MapMaterialStateProperty', () {
+      group('toString()', () {
+        test(
+          'should return null on resolve() call',
+          () {
+            final empty = MapMaterialStateProperty.resolveWith((_) => null);
+            expect(empty.resolve(MaterialState.values.toSet()), isNull);
+            expect(empty.toString(), null.toString());
+          },
+        );
+
+        test(
+          'should not-return null on resolve() call',
+          () {
+            const json = JsonMaterialStateProperty({
+              MaterialState.focused: false,
+              MaterialState.disabled: true,
+            });
+            final nonEmpty = MapMaterialStateProperty.resolveWith((s) {
+              if (s.contains(json.map.keys.last)) return json.map.values.last;
+              if (s.contains(json.map.keys.first)) return json.map.values.first;
+              return null;
+            });
+            expect(nonEmpty.toString(), json.toString());
+            expect(nonEmpty.resolve({MaterialState.values.first}), isNull);
+            expect(
+              nonEmpty.resolve(MaterialState.values.toSet()),
+              json.map.values.last,
+            );
+          },
+        );
+      });
+    });


### PR DESCRIPTION
## Description

This non-breaking adjustment solves the issue with the Instance of '_MaterialStatePropertyWith'. Currently this code from the example:
```dart
void main() async {
  WidgetsFlutterBinding.ensureInitialized();

  final themeStr = await rootBundle.loadString('assets/appainter_theme.json');
  final themeJson = jsonDecode(themeStr);
  final theme = ThemeDecoder.decodeThemeData(themeJson)!;
  print(theme.checkboxTheme.fillColor);
}
```
Prints: `Instance of '_MaterialStatePropertyWith<Color?>'`
Which is undebuggable, the current PR with the same code will return for example:
```dart
JsonMaterialStateProperty({MaterialState.hovered: Color(0xff808080)})
```
Which is also a valid `MaterialStateProperty` object.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
