### PR TITLE
fix: Add missing filledButtonTheme key

### DIFF
--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.3.1] - October 6th, 2023
+
+* Fixed missing key for `filledButtonTheme` in `ThemeDecoder.dart`
+
 ## [6.3.0] - September 27th, 2023
 
 * Added codecs for:

--- a/json_theme/lib/src/codec/theme_decoder.dart
+++ b/json_theme/lib/src/codec/theme_decoder.dart
@@ -13344,7 +13344,7 @@ class ThemeDecoder {
         // extensions: @unencodable,
 
         filledButtonTheme: decodeFilledButtonThemeData(
-          value[''],
+          value['filledButtonTheme'],
           validate: false,
         ),
 

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.3.0'
+version: '6.3.1'
 
 environment:
   sdk: '>=3.0.0 <4.0.0'

--- a/json_theme/test/json_theme_test.dart
+++ b/json_theme/test/json_theme_test.dart
@@ -10925,6 +10925,13 @@ void main() {
           ),
         ),
       ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: ButtonStyle(
+          backgroundColor: MaterialStateProperty.all(
+            const Color(0xff222222),
+          ),
+        ),
+      ),
       floatingActionButtonTheme: const FloatingActionButtonThemeData(
         backgroundColor: Color(0xeedddddd),
       ),
@@ -11220,6 +11227,21 @@ void main() {
         }
       },
       'elevatedButtonTheme': {
+        'style': {
+          'backgroundColor': {
+            'disabled': '#ff222222',
+            'dragged': '#ff222222',
+            'empty': '#ff222222',
+            'error': '#ff222222',
+            'focused': '#ff222222',
+            'hovered': '#ff222222',
+            'pressed': '#ff222222',
+            'scrolledUnder': '#ff222222',
+            'selected': '#ff222222'
+          }
+        }
+      },
+      'filledButtonTheme': {
         'style': {
           'backgroundColor': {
             'disabled': '#ff222222',


### PR DESCRIPTION
## Description

The ThemeDecoder is missing `filledButtonTheme` key for the `decodeFilledButtonThemeData` method. This PR fixes that and adds a missing test that would have caught the issue.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
