### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.3.2+1] - November 14, 2023
+
+* Automated dependency updates
+
+
 ## [6.3.2] - November 12th, 2023
 
 * Fix for `filledButtonTheme` key (thanks [ajil-apx](https://github.com/ajil-apx))
@@ -599,6 +604,7 @@
 * ~~**TODO**: Documentation~~
 * ~~**TODO**: Example App~~
 * ~~**TODO**: Unit Tests~~
+
 
 
 

--- a/json_theme/example/pubspec.yaml
+++ b/json_theme/example/pubspec.yaml
@@ -1,44 +1,52 @@
 name: 'example'
 description: 'Example application for the JSON Theme'
 publish_to: 'none'
-version: '1.0.0+36'
+version: '1.0.0+37'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-dependencies:
-  flutter:
+dependencies: 
+  flutter: 
     sdk: 'flutter'
-  form_validation: '^3.0.2+2'
-  google_fonts: '^5.1.0'
+  form_validation: '^3.1.0+8'
+  google_fonts: '^6.1.0'
   intl: '^0.18.1'
-  json_theme:
+  json_theme: 
     path: '../'
   meta: '^1.9.1'
 
-dev_dependencies:
-  flutter_lints: '^3.0.0'
-  flutter_test:
+dev_dependencies: 
+  flutter_lints: '^3.0.1'
+  flutter_test: 
     sdk: 'flutter'
 
-flutter:
+flutter: 
   uses-material-design: true
-  assets:
+  assets: 
     - 'assets/themes/'
-  fonts:
-    - family: 'lato'
-      fonts:
-        - asset: 'assets/fonts/Lato-Regular.ttf'
+  fonts: 
+    - 
+      family: 'lato'
+      fonts: 
+        - 
+          asset: 'assets/fonts/Lato-Regular.ttf'
 
-    - family: 'metal'
-      fonts:
-        - asset: 'assets/fonts/MetalMania-Regular.ttf'
+    - 
+      family: 'metal'
+      fonts: 
+        - 
+          asset: 'assets/fonts/MetalMania-Regular.ttf'
 
-    - family: 'MaterialIcons'
-      fonts:
-        - asset: 'assets/fonts/MaterialIcons-Regular.ttf'
+    - 
+      family: 'MaterialIcons'
+      fonts: 
+        - 
+          asset: 'assets/fonts/MaterialIcons-Regular.ttf'
 
-ignore_updates:
+
+
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,18 +1,19 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.3.2'
+version: '6.3.2+1'
 
-environment:
+environment: 
   sdk: '>=3.0.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-dependencies:
-  flutter:
+
+dependencies: 
+  flutter: 
     sdk: 'flutter'
   json_class: '^3.0.0+8'
   json_schema: '^5.1.3'
@@ -20,25 +21,19 @@ dependencies:
   logging: '^1.2.0'
   meta: '^1.9.1'
 
-dev_dependencies:
-  analyzer: '^6.2.0'
+dev_dependencies: 
+  analyzer: '^6.3.0'
   build: '^2.4.1'
   build_runner: '^2.4.6'
   code_builder: '^4.7.0'
   flutter_lints: '^3.0.1'
-  flutter_test:
+  flutter_test: 
     sdk: 'flutter'
-  json_theme_codegen: '^1.1.0'
+  json_theme_codegen: '^1.1.2'
   recase: '^4.1.0'
   source_gen: '^1.4.0'
 
-# dependency_overrides:
-#   json_theme_annotation:
-#     path: ../annotation
-#   json_theme_codegen:
-#     path: ../codegen
-
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `analyzer`: 6.2.0 --> 6.3.0
  * `json_theme_codegen`: 1.1.0 --> 1.1.2


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ Note: The Google Privacy Policy describes how data is handled in this      ║
  ║ service.                                                                   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...
The Flutter CLI developer tool uses Google Analytics to report usage and diagnostic data
along with package dependencies, and crash reporting to send basic crash reports.
This data is used to help improve the Dart platform, Flutter framework, and related tools.

Telemetry is not sent on the very first run.
To disable reporting of telemetry, run this terminal command:

flutter --disable-telemetry.
If you opt out of telemetry, an opt-out event will be sent,
and then no further information will be sent.
This data is collected in accordance with the
Google Privacy Policy (https://policies.google.com/privacy).



Note: meta is pinned to version 1.9.1 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter_test from sdk depends on meta 1.9.1 and analyzer >=6.3.0 depends on meta ^1.11.0, flutter_test from sdk is incompatible with analyzer >=6.3.0.
So, because json_theme depends on both analyzer ^6.3.0 and flutter_test from sdk, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on analyzer: flutter pub add dev:analyzer:^6.2.0

```


dependencies:
  * `form_validation`: 3.0.2+2 --> 3.1.0+8
  * `google_fonts`: 5.1.0 --> 6.1.0

dev_dependencies:
  * `flutter_lints`: 3.0.0 --> 3.0.1


Analysis Successful

