### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/codegen/CHANGELOG.md
+++ b/codegen/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.1.2+15] - May 7, 2024
+
+* Automated dependency updates
+
+
 ## [1.1.2+14] - April 30, 2024
 
 * Automated dependency updates
@@ -96,6 +101,7 @@
 ## [1.0.0+2] - July 4th, 2023
 
 * Initial Release
+
 
 
 

--- a/codegen/pubspec.yaml
+++ b/codegen/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme_codegen'
 description: 'A library to generate the mapping of decoders to the class names they decode'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '1.1.2+14'
+version: '1.1.2+15'
 
 environment: 
   sdk: '>=3.0.0 <4.0.0'
@@ -12,7 +12,7 @@ analyzer:
     - 'lib/**/*.g.dart'
 
 dependencies: 
-  analyzer: '^6.4.1'
+  analyzer: '^6.5.0'
   build: '^2.4.1'
   build_runner: '^2.4.9'
   code_builder: '^4.10.0'
@@ -22,7 +22,7 @@ dependencies:
 
 dev_dependencies: 
   flutter_lints: '^3.0.2'
-  test: '^1.25.4'
+  test: '^1.25.5'
 
 dependency_overrides: 
   json_theme_annotation: 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `analyzer`: 6.4.1 --> 6.5.0

dev_dependencies:
  * `test`: 1.25.4 --> 1.25.5


Error!!!
```
Resolving dependencies...


The current Dart SDK version is 3.3.4.

Because macros >=0.1.0-main.0 requires SDK version >=3.4.0-256.0.dev <4.0.0 and no versions of macros match >=0.1.0-main.0 <0.1.0-main.0, macros >=0.1.0-main.0 is forbidden.
So, because json_theme_codegen depends on analyzer ^6.5.0 which depends on macros >=0.1.0-main.0 <0.1.1, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on analyzer: dart pub add analyzer:^6.4.1

```

