### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.4.1+6] - May 7, 2024
+
+* Automated dependency updates
+
+
 ## [6.4.1+5] - April 30, 2024
 
 * Automated dependency updates
@@ -636,6 +641,7 @@
 * ~~**TODO**: Documentation~~
 * ~~**TODO**: Example App~~
 * ~~**TODO**: Unit Tests~~
+
 
 
 

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.4.1+5'
+version: '6.4.1+6'
 
 environment: 
   sdk: '>=3.2.0 <4.0.0'
@@ -16,19 +16,19 @@ dependencies:
     sdk: 'flutter'
   json_class: '^3.0.0+13'
   json_schema: '^5.1.7'
-  json_theme_annotation: '^1.0.3+6'
+  json_theme_annotation: '^1.0.3+7'
   logging: '^1.2.0'
   meta: '^1.10.0'
 
 dev_dependencies: 
-  analyzer: '^6.4.1'
+  analyzer: '^6.5.0'
   build: '^2.4.1'
   build_runner: '^2.4.9'
   code_builder: '^4.10.0'
   flutter_lints: '^3.0.2'
   flutter_test: 
     sdk: 'flutter'
-  json_theme_codegen: '^1.1.2+13'
+  json_theme_codegen: '^1.1.2+14'
   recase: '^4.1.0'
   source_gen: '^1.5.0'
 


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_theme_annotation`: 1.0.3+6 --> 1.0.3+7

dev_dependencies:
  * `analyzer`: 6.4.1 --> 6.5.0
  * `json_theme_codegen`: 1.1.2+13 --> 1.1.2+14


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use                                    ║
  ║ 'flutter config --no-cli-animations'.                                      ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...


Note: meta is pinned to version 1.11.0 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because every version of flutter_test from sdk depends on meta 1.11.0 and analyzer >=6.5.0 depends on meta ^1.14.0, flutter_test from sdk is incompatible with analyzer >=6.5.0.
So, because json_theme depends on both analyzer ^6.5.0 and flutter_test from sdk, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on analyzer: flutter pub add dev:analyzer:^6.4.1

```


