### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [6.5.0+2] - May 28, 2024
+
+* Automated dependency updates
+
+
 ## [6.5.0+1] - May 14th, 2024
 
 * Swapped MaterialStateProperty with WidgetStateProperty in preperation for other Flutter 3.22 work.
@@ -641,44 +646,3 @@
 * ~~**TODO**: Documentation~~
 * ~~**TODO**: Example App~~
 * ~~**TODO**: Unit Tests~~
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,63 +1,58 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.5.0+1'
+version: '6.5.0+2'
 
-environment:
+environment: 
   sdk: '>=3.2.0 <4.0.0'
 
-analyzer:
-  exclude:
+analyzer: 
+  exclude: 
     - 'lib/generated/**'
     - 'lib/**/*.g.dart'
 
-dependencies:
-  flutter:
+dependencies: 
+  flutter: 
     sdk: 'flutter'
   json_class: '^3.0.0+13'
   json_schema: '^5.1.7'
-  json_theme_annotation: '^1.0.3+6'
+  json_theme_annotation: '^1.0.3+7'
   logging: '^1.2.0'
   meta: '^1.12.0'
 
-dev_dependencies:
-  analyzer: '^6.4.1'
+dev_dependencies: 
+  analyzer: '^6.5.0'
   build: '^2.4.1'
-  build_runner: '^2.4.9'
+  build_runner: '^2.4.10'
   code_builder: '^4.10.0'
   flutter_lints: '^4.0.0'
-  flutter_test:
+  flutter_test: 
     sdk: 'flutter'
-  json_theme_codegen: '^1.1.2+13'
+  json_theme_codegen: '^1.1.2+15'
   recase: '^4.1.0'
   source_gen: '^1.5.0'
 
-permittedLicenses:
-  - Apache-2.0
-  - BSD-2-Clause
-  - BSD-3-Clause
-  - MIT
-  - MIT-Modern-Variant
-  - MPL-2.0
-  - Zlib
+permittedLicenses: 
+  - 'Apache-2.0'
+  - 'BSD-2-Clause'
+  - 'BSD-3-Clause'
+  - 'MIT'
+  - 'MIT-Modern-Variant'
+  - 'MPL-2.0'
+  - 'Zlib'
 
-# The [license_checker](https://pub.dev/packages/license_checker) package cannot
-# detect the built in Flutter packages because they aren't published to pub.dev
-# and do not have a LICENSE file in their respective folders.  So this section
-# informs the license_checker that all the built in Flutter packages all have
-# the same BSD-3-Clause license as Flutter itself. 
 packageLicenseOverride: 
-  flutter: BSD-3-Clause
-  flutter_driver: BSD-3-Clause
-  flutter_goldens: BSD-3-Clause
-  flutter_localizations: BSD-3-Clause
-  flutter_web_plugins: BSD-3-Clause
-  flutter_test: BSD-3-Clause
-  fuchsia_remote_debug_protocol: BSD-3-Clause
-  integration_test: BSD-3-Clause
-  rxdart: Apache-2.0
+  flutter: 'BSD-3-Clause'
+  flutter_driver: 'BSD-3-Clause'
+  flutter_goldens: 'BSD-3-Clause'
+  flutter_localizations: 'BSD-3-Clause'
+  flutter_web_plugins: 'BSD-3-Clause'
+  flutter_test: 'BSD-3-Clause'
+  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
+  integration_test: 'BSD-3-Clause'
+  rxdart: 'Apache-2.0'
 
-ignore_updates:
+ignore_updates: 
   - 'archive'
   - 'async'
   - 'boolean_selector'


### PR DESCRIPTION
PR created automatically


dependencies:
  * `json_theme_annotation`: 1.0.3+6 --> 1.0.3+7

dev_dependencies:
  * `analyzer`: 6.4.1 --> 6.5.0
  * `build_runner`: 2.4.9 --> 2.4.10
  * `json_theme_codegen`: 1.1.2+13 --> 1.1.2+15


Error!!!
```

  ╔════════════════════════════════════════════════════════════════════════════╗
  ║                 Welcome to Flutter! - https://flutter.dev                  ║
  ║                                                                            ║
  ║ The Flutter tool uses Google Analytics to anonymously report feature usage ║
  ║ statistics and basic crash reports. This data is used to help improve      ║
  ║ Flutter tools over time.                                                   ║
  ║                                                                            ║
  ║ Flutter tool analytics are not sent on the very first run. To disable      ║
  ║ reporting, type 'flutter config --no-analytics'. To display the current    ║
  ║ setting, type 'flutter config'. If you opt out of analytics, an opt-out    ║
  ║ event will be sent, and then no further information will be sent by the    ║
  ║ Flutter tool.                                                              ║
  ║                                                                            ║
  ║ By downloading the Flutter SDK, you agree to the Google Terms of Service.  ║
  ║ The Google Privacy Policy describes how data is handled in this service.   ║
  ║                                                                            ║
  ║ Moreover, Flutter includes the Dart SDK, which may send usage metrics and  ║
  ║ crash reports to Google.                                                   ║
  ║                                                                            ║
  ║ Read about data we send with crash reports:                                ║
  ║ https://flutter.dev/docs/reference/crash-reporting                         ║
  ║                                                                            ║
  ║ See Google's privacy policy:                                               ║
  ║ https://policies.google.com/privacy                                        ║
  ║                                                                            ║
  ║ To disable animations in this tool, use                                    ║
  ║ 'flutter config --no-cli-animations'.                                      ║
  ╚════════════════════════════════════════════════════════════════════════════╝

Resolving dependencies...


Because json_theme_codegen >=1.1.2+15 depends on analyzer >=6.2.0 <6.5.0 and json_theme depends on analyzer ^6.5.0, json_theme_codegen >=1.1.2+15 is forbidden.
So, because json_theme depends on json_theme_codegen ^1.1.2+15, version solving failed.


You can try the following suggestion to make the pubspec resolve:
* Consider downgrading your constraint on analyzer: flutter pub add dev:analyzer:^6.4.1

```


