### PR TITLE
chore: add missing switch case for AutovalidateMode.onUnfocus

### DIFF
--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [6.5.0+1] - May 14th, 2024
+## [6.5.1+1] - August 7th, 2024
 
 * Add missing case AutovalidateMode.onUnfocus in encoder
 

--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [6.5.0+1] - May 14th, 2024
 
+* Add missing case AutovalidateMode.onUnfocus in encoder
+
+
+## [6.5.0+1] - May 14th, 2024
+
 * Swapped MaterialStateProperty with WidgetStateProperty in preperation for other Flutter 3.22 work.
 
 

--- a/json_theme/lib/src/codec/theme_encoder.dart
+++ b/json_theme/lib/src/codec/theme_encoder.dart
@@ -238,32 +238,12 @@ class ThemeEncoder {
     return _stripDynamicNull(result);
   }
 
-  /// Encodes the given [value] to a [String].  Supported values are:
-  /// * `always`
-  /// * `disabled`
-  /// * `onUserInteraction`
-  /// * `onUnfocus`
+  /// Encodes the given [value] to a [String].
   static String? encodeAutovalidateMode(AutovalidateMode? value) {
     String? result;
 
     if (value != null) {
-      switch (value) {
-        case AutovalidateMode.always:
-          result = 'always';
-          break;
-
-        case AutovalidateMode.disabled:
-          result = 'disabled';
-          break;
-
-        case AutovalidateMode.onUserInteraction:
-          result = 'onUserInteraction';
-          break;
-
-        case AutovalidateMode.onUnfocus:
-          result = 'onUnfocus';
-          break;
-      }
+      return value.name;
     }
 
     return _stripDynamicNull(result);

--- a/json_theme/lib/src/codec/theme_encoder.dart
+++ b/json_theme/lib/src/codec/theme_encoder.dart
@@ -258,6 +258,10 @@ class ThemeEncoder {
         case AutovalidateMode.onUserInteraction:
           result = 'onUserInteraction';
           break;
+
+        case AutovalidateMode.onUnfocus:
+          result = 'onUnfocus';
+          break;
       }
     }
 

--- a/json_theme/lib/src/codec/theme_encoder.dart
+++ b/json_theme/lib/src/codec/theme_encoder.dart
@@ -242,6 +242,7 @@ class ThemeEncoder {
   /// * `always`
   /// * `disabled`
   /// * `onUserInteraction`
+  /// * `onUnfocus`
   static String? encodeAutovalidateMode(AutovalidateMode? value) {
     String? result;
 

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.5.1+2'
+version: '6.5.1+1'
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.5.0+1'
+version: '6.5.1+2'
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/json_theme/test/json_theme_test.dart
+++ b/json_theme/test/json_theme_test.dart
@@ -495,35 +495,11 @@ void main() {
       AutovalidateMode.always,
     );
 
-    expect(
-      ThemeDecoder.decodeAutovalidateMode('always'),
-      AutovalidateMode.always,
-    );
-    expect(
-      ThemeDecoder.decodeAutovalidateMode('disabled'),
-      AutovalidateMode.disabled,
-    );
-    expect(
-      ThemeDecoder.decodeAutovalidateMode('onUserInteraction'),
-      AutovalidateMode.onUserInteraction,
-    );
-
-    expect(
-      ThemeEncoder.encodeAutovalidateMode(AutovalidateMode.always),
-      'always',
-    );
-    expect(
-      ThemeEncoder.encodeAutovalidateMode(AutovalidateMode.disabled),
-      'disabled',
-    );
-    expect(
-      ThemeEncoder.encodeAutovalidateMode(AutovalidateMode.onUserInteraction),
-      'onUserInteraction',
-    );
-    expect(
-      ThemeEncoder.encodeAutovalidateMode(AutovalidateMode.onUnfocus),
-      'onUnfocus',
-    );
+    // Test each values from AutovalidateMode enum
+    for (var value in AutovalidateMode.values) {
+      expect(ThemeDecoder.decodeAutovalidateMode(value.name), value);
+      expect(ThemeEncoder.encodeAutovalidateMode(value), value.name);
+    }
   });
 
   test('Axis', () {

--- a/json_theme/test/json_theme_test.dart
+++ b/json_theme/test/json_theme_test.dart
@@ -520,6 +520,10 @@ void main() {
       ThemeEncoder.encodeAutovalidateMode(AutovalidateMode.onUserInteraction),
       'onUserInteraction',
     );
+    expect(
+      ThemeEncoder.encodeAutovalidateMode(AutovalidateMode.onUnfocus),
+      'onUnfocus',
+    );
   });
 
   test('Axis', () {


### PR DESCRIPTION
## Description

This allows the package to build with flutter version 3.24.x.
Just adding `onUnfocus` case on switch to remove compilation issue.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change
Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.

<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
