### PR TITLE
chore: ignore deprecated use of 'ButtonBarThemeData' and fix unit tests

### DIFF
--- a/json_theme/CHANGELOG.md
+++ b/json_theme/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [6.5.1+2] - September 4th, 2024
+
+* Fix unit tests and ignore deprecated member of 'ButonBarThemeData' which is deprecated since v3.21.0-10.0.pre.
+
 ## [6.5.1+1] - August 7th, 2024
 
 * Add missing case AutovalidateMode.onUnfocus in encoder

--- a/json_theme/lib/src/codec/theme_decoder.dart
+++ b/json_theme/lib/src/codec/theme_decoder.dart
@@ -512,6 +512,7 @@ class ThemeDecoder {
           'always',
           'disabled',
           'onUserInteraction',
+          'onUnfocus',
         ],
         value,
       );
@@ -522,17 +523,9 @@ class ThemeDecoder {
           value: value,
           validate: validate,
         ));
-        switch (value) {
-          case 'always':
-            result = AutovalidateMode.always;
-            break;
-          case 'disabled':
-            result = AutovalidateMode.disabled;
-            break;
-          case 'onUserInteraction':
-            result = AutovalidateMode.onUserInteraction;
-            break;
-        }
+
+        result = AutovalidateMode.values
+            .firstWhere((e) => e.toString() == 'AutovalidateMode.$value');
       }
     }
 
@@ -2040,6 +2033,7 @@ class ThemeDecoder {
     return result;
   }
 
+  // ignore: deprecated_member_use
   /// Decodes the given [value] to an [ButtonBarThemeData].  This expects the
   /// given [value] to follow the structure below:
   ///
@@ -2064,12 +2058,15 @@ class ThemeDecoder {
   ///  * [decodeMainAxisAlignment]
   ///  * [decodeMainAxisSize]
   ///  * [decodeVerticalDirection]
+  // ignore: deprecated_member_use
   static ButtonBarThemeData? decodeButtonBarThemeData(
     dynamic value, {
     bool validate = true,
   }) {
+    // ignore: deprecated_member_use
     ButtonBarThemeData? result;
 
+    // ignore: deprecated_member_use
     if (value is ButtonBarThemeData) {
       result = value;
     } else if (value != null) {
@@ -2078,6 +2075,7 @@ class ThemeDecoder {
         value: value,
         validate: validate,
       ));
+      // ignore: deprecated_member_use
       result = ButtonBarThemeData(
         alignment: decodeMainAxisAlignment(
           value['alignment'],
@@ -12186,6 +12184,7 @@ class ThemeDecoder {
           value['brightness'],
           validate: false,
         ),
+        // ignore: deprecated_member_use
         buttonBarTheme: decodeButtonBarThemeData(
           value['buttonBarTheme'],
           validate: false,

--- a/json_theme/lib/src/codec/theme_encoder.dart
+++ b/json_theme/lib/src/codec/theme_encoder.dart
@@ -1106,6 +1106,7 @@ class ThemeEncoder {
   ///  * [encodeMainAxisSize]
   ///  * [encodeVerticalDirection]
   static Map<String, dynamic>? encodeButtonBarThemeData(
+    // ignore: deprecated_member_use
     ButtonBarThemeData? value,
   ) {
     Map<String, dynamic>? result;
@@ -7082,6 +7083,7 @@ class ThemeEncoder {
         ),
         'bottomSheetTheme': encodeBottomSheetThemeData(value.bottomSheetTheme),
         'brightness': encodeBrightness(value.brightness),
+        // ignore: deprecated_member_use
         'buttonBarTheme': encodeButtonBarThemeData(value.buttonBarTheme),
         'buttonTheme': encodeButtonThemeData(value.buttonTheme),
         'canvasColor': encodeColor(value.canvasColor),

--- a/json_theme/lib/src/schema/schemas/enums/autovalidate_mode_schema.dart
+++ b/json_theme/lib/src/schema/schemas/enums/autovalidate_mode_schema.dart
@@ -15,6 +15,7 @@ class AutovalidateModeSchema {
       'always',
       'disabled',
       'onUserInteraction',
+      'onUnfocus',
     ]),
   };
 }

--- a/json_theme/pubspec.yaml
+++ b/json_theme/pubspec.yaml
@@ -1,7 +1,7 @@
 name: 'json_theme'
 description: 'A library to dynamically generate a ThemeData object from a JSON file or dynamic map object'
 homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '6.5.1+1'
+version: '6.5.1+2'
 
 environment:
   sdk: '>=3.2.0 <4.0.0'

--- a/json_theme/test/json_theme_test.dart
+++ b/json_theme/test/json_theme_test.dart
@@ -1218,7 +1218,7 @@ void main() {
         },
         'image': {
           'alignment': 'center',
-          'filterQuality': 'low',
+          'filterQuality': 'medium',
           'image': {
             'bytes': base64Image,
             'scale': 1.0,
@@ -1440,6 +1440,7 @@ void main() {
     expect(ThemeDecoder.decodeButtonBarThemeData(null), null);
     expect(ThemeEncoder.encodeButtonBarThemeData(null), null);
 
+    // ignore: deprecated_member_use
     const entry = ButtonBarThemeData(
       alignment: MainAxisAlignment.spaceEvenly,
       buttonAlignedDropdown: true,
@@ -10184,6 +10185,7 @@ void main() {
       bottomSheetTheme: const BottomSheetThemeData(
         backgroundColor: Color(0xff000000),
       ),
+      // ignore: deprecated_member_use
       buttonBarTheme: const ButtonBarThemeData(buttonHeight: 3.0),
       buttonTheme: const ButtonThemeData(buttonColor: Color(0xffbbbbbb)),
       canvasColor: const Color(0xffcccccc),


### PR DESCRIPTION
## Description

Ignore the use of `ButtonBarThemeData` and fix some unit tests (according to #208 PR)


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Code Style Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze` or `dart analyze`) does not report any problems on my PR.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I am authorized to release this code under the MIT License and agree to do so

## UI Change

Does your PR affect any UI screens?

- [ ] Yes, the relevant screens are included below.
- [x] No, there are no UI impacts with this PR.


<!-- Links -->
[Code Style Guide]: https://github.com/peiffer-innovations/documentation/blob/main/CODE_STYLE.md
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
