### PR TITLE
fix: update ThemeData property types to support Flutter 3.32.0

### DIFF
--- a/json_theme/lib/src/codec/theme_decoder.dart
+++ b/json_theme/lib/src/codec/theme_decoder.dart
@@ -11942,7 +11942,7 @@ class ThemeDecoder {
         ),
         canvasColor: decodeColor(value['canvasColor'], validate: false),
         cardColor: decodeColor(value['cardColor'], validate: false),
-        cardTheme: decodeCardTheme(value['cardTheme'], validate: false),
+        cardTheme: decodeCardThemeData(value['cardTheme'], validate: false),
         checkboxTheme: decodeCheckboxThemeData(
           value['checkboxTheme'],
           validate: false,
@@ -11962,7 +11962,10 @@ class ThemeDecoder {
           value['dataTableTheme'],
           validate: false,
         ),
-        dialogTheme: decodeDialogTheme(value['dialogTheme'], validate: false),
+        dialogTheme: decodeDialogThemeData(
+          value['dialogTheme'],
+          validate: false,
+        ),
         disabledColor: decodeColor(value['disabledColor'], validate: false),
         dividerColor: decodeColor(value['dividerColor'], validate: false),
         dividerTheme: decodeDividerThemeData(
@@ -12124,7 +12127,10 @@ class ThemeDecoder {
           value['switchTheme'],
           validate: false,
         ),
-        tabBarTheme: decodeTabBarTheme(value['tabBarTheme'], validate: false),
+        tabBarTheme: decodeTabBarThemeData(
+          value['tabBarTheme'],
+          validate: false,
+        ),
         textButtonTheme: decodeTextButtonThemeData(
           value['textButtonTheme'],
           validate: false,

--- a/json_theme/lib/src/codec/theme_encoder.dart
+++ b/json_theme/lib/src/codec/theme_encoder.dart
@@ -1332,11 +1332,11 @@ class ThemeEncoder {
   ///  * [encodeColor]
   ///  * [encodeEdgeInsetsGeometry]
   ///  * [encodeShapeBorder]
-  static Map<String, dynamic>? encodeCardTheme(CardTheme? value) {
+  static Map<String, dynamic>? encodeCardTheme(CardThemeData? value) {
     Map<String, dynamic>? result;
 
     if (value != null) {
-      result = <String, dynamic>{'data': encodeCardThemeData(value.data)};
+      result = <String, dynamic>{'data': encodeCardThemeData(value)};
     }
 
     return _stripDynamicNull(result);

--- a/json_theme/test/json_theme_test.dart
+++ b/json_theme/test/json_theme_test.dart
@@ -1599,7 +1599,7 @@ void main() {
 
     const corner = {'type': 'elliptical', 'x': 12.0, 'y': 12.0};
 
-    var entry = ThemeDecoder.decodeCardTheme({
+    var entry = ThemeDecoder.decodeCardThemeData({
       'clipBehavior': 'hardEdge',
       'color': '#ff111111',
       'elevation': 3.0,
@@ -1623,7 +1623,7 @@ void main() {
       },
     });
 
-    expect(ThemeDecoder.decodeCardTheme(entry), entry);
+    expect(ThemeDecoder.decodeCardThemeData(entry), entry);
 
     var encoded = ThemeEncoder.encodeCardTheme(entry);
 
@@ -1653,21 +1653,19 @@ void main() {
       },
     });
 
-    entry = CardTheme(
-      data: CardThemeData(
-        clipBehavior: Clip.hardEdge,
-        color: const Color(0xff111111),
-        elevation: 3.0,
-        margin: const EdgeInsets.all(10.0),
-        shadowColor: const Color(0xff222222),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(12.0),
-          side: BorderSide.none,
-        ),
+    entry = CardThemeData(
+      clipBehavior: Clip.hardEdge,
+      color: const Color(0xff111111),
+      elevation: 3.0,
+      margin: const EdgeInsets.all(10.0),
+      shadowColor: const Color(0xff222222),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(12.0),
+        side: BorderSide.none,
       ),
     );
 
-    expect(ThemeDecoder.decodeCardTheme(entry), entry);
+    expect(ThemeDecoder.decodeCardThemeData(entry), entry);
 
     encoded = ThemeEncoder.encodeCardTheme(entry);
 
@@ -8300,7 +8298,7 @@ void main() {
       buttonTheme: const ButtonThemeData(buttonColor: Color(0xffbbbbbb)),
       canvasColor: const Color(0xffcccccc),
       cardColor: const Color(0xffdddddd),
-      cardTheme: const CardTheme(color: Color(0xffeeeeee)),
+      cardTheme: const CardThemeData(color: Color(0xffeeeeee)),
       checkboxTheme: CheckboxThemeData(
         fillColor: WidgetStateProperty.all(const Color(0xff123456)),
       ),
@@ -8341,7 +8339,7 @@ void main() {
         headingTextStyle: const TextStyle(),
         horizontalMargin: 1.0,
       ),
-      dialogTheme: const DialogTheme(backgroundColor: Color(0xee999999)),
+      dialogTheme: const DialogThemeData(backgroundColor: Color(0xee999999)),
       disabledColor: const Color(0xee000000),
       dividerColor: const Color(0xeeaaaaaa),
       dividerTheme: const DividerThemeData(color: Color(0xeebbbbbb)),
@@ -8442,7 +8440,7 @@ void main() {
       switchTheme: SwitchThemeData(
         thumbColor: WidgetStateProperty.all(const Color(0xff123456)),
       ),
-      tabBarTheme: const TabBarTheme(labelColor: Color(0xccffffff)),
+      tabBarTheme: const TabBarThemeData(labelColor: Color(0xccffffff)),
       textButtonTheme: TextButtonThemeData(
         style: ButtonStyle(
           backgroundColor: WidgetStateProperty.all(const Color(0xff222222)),


### PR DESCRIPTION
# Description

This pull request restores compatibility of json_theme with Flutter 3.32.0 and above. Several theme-related classes in ThemeData were renamed (adding the Data suffix), causing downstream consumers to fail at compile time. This PR updates all affected properties, ensuring seamless JSON-to-theme parsing on the latest Flutter SDK.

solves #264 