### PR TITLE
BOT: Dart Dependency Updater

### DIFF
--- a/packages/annotation/CHANGELOG.md
+++ b/packages/annotation/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [1.0.3+19] - November 4, 2025
+
+* Automated dependency updates
+
+
 ## [1.0.3+18] - June 10, 2025
 
 * Automated dependency updates

--- a/packages/annotation/pubspec.yaml
+++ b/packages/annotation/pubspec.yaml
@@ -1,64 +1,64 @@
-name: 'json_theme_annotation'
-description: 'Simple package holding the annotations needed by the JsonTheme code generator.'
-homepage: 'https://github.com/peiffer-innovations/json_theme'
-version: '1.0.3+18'
+name: "json_theme_annotation"
+description: "Simple package holding the annotations needed by the JsonTheme code generator."
+homepage: "https://github.com/peiffer-innovations/json_theme"
+version: "1.0.3+19"
 
 environment:
-  sdk: '^3.8.0'
-resolution: 'workspace'
+  sdk: "^3.8.0"
+resolution: "workspace"
 
 analyzer:
   exclude:
-    - 'lib/generated/**'
-    - 'lib/**/*.g.dart'
+    - "lib/generated/**"
+    - "lib/**/*.g.dart"
 
 dev_dependencies:
-  flutter_lints: '^6.0.0'
-  test: '^1.25.0'
+  flutter_lints: "^6.0.0"
+  test: "^1.26.3"
 
 permittedLicenses:
-  - 'Apache-2.0'
-  - 'BSD-2-Clause'
-  - 'BSD-3-Clause'
-  - 'MIT'
-  - 'MIT-Modern-Variant'
-  - 'MPL-2.0'
-  - 'Zlib'
+  - "Apache-2.0"
+  - "BSD-2-Clause"
+  - "BSD-3-Clause"
+  - "MIT"
+  - "MIT-Modern-Variant"
+  - "MPL-2.0"
+  - "Zlib"
 
 packageLicenseOverride:
-  flutter: 'BSD-3-Clause'
-  flutter_driver: 'BSD-3-Clause'
-  flutter_goldens: 'BSD-3-Clause'
-  flutter_localizations: 'BSD-3-Clause'
-  flutter_web_plugins: 'BSD-3-Clause'
-  flutter_test: 'BSD-3-Clause'
-  fuchsia_remote_debug_protocol: 'BSD-3-Clause'
-  integration_test: 'BSD-3-Clause'
-  rxdart: 'Apache-2.0'
+  flutter: "BSD-3-Clause"
+  flutter_driver: "BSD-3-Clause"
+  flutter_goldens: "BSD-3-Clause"
+  flutter_localizations: "BSD-3-Clause"
+  flutter_web_plugins: "BSD-3-Clause"
+  flutter_test: "BSD-3-Clause"
+  fuchsia_remote_debug_protocol: "BSD-3-Clause"
+  integration_test: "BSD-3-Clause"
+  rxdart: "Apache-2.0"
 
 ignore_updates:
-  - 'archive'
-  - 'async'
-  - 'boolean_selector'
-  - 'characters'
-  - 'charcode'
-  - 'collection'
-  - 'clock'
-  - 'crypto'
-  - 'fake_async'
-  - 'file'
-  - 'matcher'
-  - 'material_color_utilities'
-  - 'meta'
-  - 'path'
-  - 'source_span'
-  - 'stack_trace'
-  - 'stream_channel'
-  - 'string_scanner'
-  - 'sync_http'
-  - 'term_glyph'
-  - 'test_api'
-  - 'typed_data'
-  - 'uuid'
-  - 'vector_math'
-  - 'webdriver'
+  - "archive"
+  - "async"
+  - "boolean_selector"
+  - "characters"
+  - "charcode"
+  - "collection"
+  - "clock"
+  - "crypto"
+  - "fake_async"
+  - "file"
+  - "matcher"
+  - "material_color_utilities"
+  - "meta"
+  - "path"
+  - "source_span"
+  - "stack_trace"
+  - "stream_channel"
+  - "string_scanner"
+  - "sync_http"
+  - "term_glyph"
+  - "test_api"
+  - "typed_data"
+  - "uuid"
+  - "vector_math"
+  - "webdriver"


### PR DESCRIPTION
PR created automatically


dev_dependencies:
  * `test`: 1.25.0 --> 1.26.3


Error!!!
```
Resolving dependencies in `/home/runner/work/json_theme/json_theme`...


Note: test_api is pinned to version 0.7.6 by flutter_test from the flutter SDK.
See https://dart.dev/go/sdk-version-pinning for details.


Because json_theme depends on flutter_test from sdk which depends on test_api 0.7.6, test_api 0.7.6 is required.
So, because json_theme_annotation depends on test ^1.26.3 which depends on test_api 0.7.7, version solving failed.

```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package changelog for version 1.0.3+19 with automated dependency information.
  * Standardized configuration file formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->